### PR TITLE
Drop TRUE_LOS rows not inplace

### DIFF
--- a/data/formatting.py
+++ b/data/formatting.py
@@ -78,7 +78,11 @@ def drop_true_los_rows(df):
     spell_ids += list(negative_stays.iloc[np.where(negative_stays < 0)].index)
 
     spell_ids = list(set(spell_ids))
-    df.set_index('SPELL_ID').drop(spell_ids, axis=0, inplace=True).reset_index()
+
+    if spell_ids != []:
+        df = df.set_index('SPELL_ID').drop(spell_ids, axis=0).reset_index()
+
+    return df
 
 def rename_columns(df):
     """ Rename some of the poorly/confusingly named columns. """

--- a/data/run_formatting.py
+++ b/data/run_formatting.py
@@ -26,8 +26,8 @@ def main_formatting(df):
     format_period_cols(df)
     format_dates(df)
     true_length_of_stay(df)
-    drop_true_los_rows(df)
     rename_columns(df)
+    df = drop_true_los_rows(df)
 
     return df
 


### PR DESCRIPTION
For some reason, dropping rows inplace was throwing errors about the
dataframe being formatted being a NoneType object.

This is a simple work around, and could be better practice rather than
editing our local variable globally with inplace changes?