### PR TITLE
Use conda env only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,5 @@
 name: CI
+description: Tests to ensure the document can be compiled and tested correctly.
 
 on:
     push:
@@ -10,11 +11,13 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.7
-        uses: actions/setup-python@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up conda and environment
+        uses: matthewrmshin/conda-action@v1
         with:
-          python-version: 3.7
+          args: conda env update -f ./environment.yml
 
       - name: Install latex libs
         run: |
@@ -33,11 +36,6 @@ jobs:
           sudo getnonfreefonts --sys garamondx
           sudo getnonfreefonts --sys -r
 
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      
       - name: Clone submodules
         run: git submodule update --init --recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
         with:
           environment-file: ./environment.yml
           activate-environment: 'thesis'
+      - name: Print conda and Python information
+        run: |
+          conda info
+          which python
+          python --version
       - name: Install latex libs
         run: |
           sudo apt-get update
@@ -39,10 +44,10 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Combine and clean bibliography
-        run: inv bibliography
+        run: python -m invoke bibliography
       - name: Test PDF compiles
-        run: inv compile --engine=xelatex
+        run: python -m invoke compile --engine=xelatex
       - name: Doctest source
-        run: inv doctest
+        run: python -m invoke doctest
       - name: Test spellcheck
-        run: inv spellcheck
+        run: python -m invoke spellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Activate environment
         run: |
           conda init
+          bash
           conda activate thesis
       - name: Install latex libs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,12 +20,6 @@ jobs:
         with:
           environment-file: ./environment.yml
           activate-environment: thesis
-      - name: Print conda and Python information
-        shell: bash -l {0}
-        run: |
-          conda info
-          which python
-          python --version
       - name: Install latex libs
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           args: conda env update -f ./environment.yml
       - name: Activate environment
-        run: source activate thesis
+        run: |
+          conda init
+          conda activate thesis
       - name: Install latex libs
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Set up conda and environment
-        uses: matthewrmshin/conda-action@v1
+      - name: Set up miniconda and environment
+        uses: goanpeca/setup-miniconda@v1.6.0
         with:
-          args: conda env update -f ./environment.yml
-      - name: Activate environment
-        run: |
-          conda init
-          bash
-          conda activate thesis
+          environment-file: ./environment.yml
+          activate-environment: 'thesis'
       - name: Install latex libs
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: goanpeca/setup-miniconda@v1.6.0
         with:
           environment-file: ./environment.yml
-          activate-environment: 'thesis'
+          activate-environment: thesis
       - name: Print conda and Python information
         run: |
           conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           args: conda env update -f ./environment.yml
       - name: Activate environment
-        run: conda activate thesis
+        run: source activate thesis
       - name: Install latex libs
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
         uses: matthewrmshin/conda-action@v1
         with:
           args: conda env update -f ./environment.yml
+      - name: Activate environment
         run: conda activate thesis
       - name: Install latex libs
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-name: CI
-description: Tests to ensure the document can be compiled and tested correctly.
+name: CI for thesis
 
 on:
     push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ on:
 
 jobs:
   build:
-
+    defaults:
+      run:
+        shell: bash -l {0}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -45,10 +47,10 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Combine and clean bibliography
-        run: python -m invoke bibliography
+        run: inv bibliography
       - name: Test PDF compiles
-        run: python -m invoke compile --engine=xelatex
+        run: inv compile --engine=xelatex
       - name: Doctest source
-        run: python -m invoke doctest
+        run: inv doctest
       - name: Test spellcheck
-        run: python -m invoke spellcheck
+        run: inv spellcheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
           environment-file: ./environment.yml
           activate-environment: thesis
       - name: Print conda and Python information
+        shell: bash -l {0}
         run: |
           conda info
           which python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         uses: matthewrmshin/conda-action@v1
         with:
           args: conda env update -f ./environment.yml
-
+        run: conda activate thesis
       - name: Install latex libs
         run: |
           sudo apt-get update

--- a/count.py
+++ b/count.py
@@ -57,8 +57,6 @@ def main():
 
     gh = Github(os.getenv('GITHUB_TOKEN'))
     event = read_json(os.getenv('GITHUB_EVENT_PATH'))
-    print("GITHUB_EVENT_PATH\n", event)
-
     pr = get_pull_request(gh, event)
 
     comment = get_summary()

--- a/environment.yml
+++ b/environment.yml
@@ -1,32 +1,22 @@
-name: hdw-thesis
+name: thesis
 channels:
 - defaults
 - conda-forge
 dependencies:
- - python=3
- - numpy
- - h5py
- - scipy
- - toolz
- - bokeh
- - dask
- - distributed
- - notebook
- - matplotlib
- - seaborn
- - Pillow
- - pandas
- - pandas-datareader
- - pytables
- - scikit-learn
- - snakeviz
- - ujson
- - graphviz
- - pip
- - s3fs
- - fastparquet
+ - python=3.7
+ - dask=2.21.0
+ - matplotlib=3.2.2
+ - numpy=1.18.5
+ - pandas=1.0.5
+ - scikit-learn=0.23.1
+ - scipy=1.5.0
+ - pip=20.1.1
  - pip:
-         - graphviz 
-         - cachey
-prefix: /Users/henrywilde/anaconda3/envs/hdw-thesis
-
+   - alphashape==1.0.1
+   - bibtexparser==1.2.0
+   - descartes==1.1.0
+   - edo==0.2.1
+   - invoke==1.4.1
+   - graphviz==0.14.1
+   - pygments==2.5.2
+   - shapely==1.6.4.post2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-bibtexparser==1.1.0
-invoke==1.4.1
-pandas==1.0.1
-pygments==2.5.2


### PR DESCRIPTION
To make my life easier, I'll be using a single conda environment for the whole thesis. Each submodule has its own `requirements.txt` and/or `environment.yml` files still but I will only use the root `environment.yml` for compilation, testing and doctesting.

This also means the CI workflow has to be adjusted.