### PR TITLE
Get data chapter to render for GitHub actions

### DIFF
--- a/appendix.tex
+++ b/appendix.tex
@@ -1,3 +1,24 @@
-\chapter*{Appendix}
+\chapter*{Appendices}
+\renewcommand{\thesection}{\Alph{section}}
+\renewcommand{\thetable}{\Alph{section}.\arabic{table}}
+\pagestyle{appendixstyle}
 
-This is the appendix.
+\appendix%
+\section{Supplementary tables}\label{app:tables}
+
+This appendix contains tables that add to the exploratory analysis conducted in
+Chapter~\ref{chp:data}. In particular, these tables consider the key attributes
+of the dataset that are connected with costs.
+
+\begin{table}
+        \centering
+    \rotatebox{90}{%
+        \resizebox{.75\paperheight}{!}{%
+            \input{\texpath/diab_summary.tex}
+        }
+    }
+        \caption{%
+            Spell-level statistics for each of the key attributes in the
+            diabetic population (and non-diabetic population in parentheses)
+        }\label{tab:diab_summary}
+    \end{table}

--- a/appendix.tex
+++ b/appendix.tex
@@ -10,15 +10,3 @@ This appendix contains tables that add to the exploratory analysis conducted in
 Chapter~\ref{chp:data}. In particular, these tables consider the key attributes
 of the dataset that are connected with costs.
 
-\begin{table}
-        \centering
-    \rotatebox{90}{%
-        \resizebox{.75\paperheight}{!}{%
-            \input{\texpath/diab_summary.tex}
-        }
-    }
-        \caption{%
-            Spell-level statistics for each of the key attributes in the
-            diabetic population (and non-diabetic population in parentheses)
-        }\label{tab:diab_summary}
-    \end{table}

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -1,4 +1,5 @@
 \chapter{An exploratory analysis of administrative data}
+\label{chp:data}
 
 \renewcommand{\texpath}{chapters/data/paper/tex}
 
@@ -555,27 +556,10 @@ stay longer in the hospital. As a result, they will typically incur higher costs
 than non-diabetic patients. All of these observations suggest that diabetic
 patients represent a population whose spells are more severe on average than the
 typical patient. Therefore, they will likely have a larger effect on the
-hospital system on the whole. Again, a more detailed breakdown of the skeleton
-for each of these attributes as well as the other key attributes is given in
-Table~\ref{tab:diab_summary}. This table also shows a comparison between both
+hospital system on the whole. A more detailed breakdown of the skeleton for each
+of these attributes as well as the other key attributes is given in
+Appendix~\ref{app:tables}. That table also shows a comparison between both
 populations being considered in this section.
-
-\afterpage{%
-    \clearpage%
-    \begin{landscape}
-        \thispagestyle{empty}
-        \begin{table}
-        \centering
-            \resizebox{.8\paperheight}{!}{%
-                \input{\texpath/diab_summary.tex}
-            }
-            \caption{%
-                Spell-level statistics for each of the key attributes in the
-                diabetic population (and non-diabetic population in parentheses)
-            }\label{tab:diab_summary}
-        \end{table}
-    \end{landscape}
-}
 
 \begin{figure}
     \centering

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -563,11 +563,9 @@ populations being considered in this section.
 
 \begin{sidewaystable}
     \centering
-%    \rotatebox{90}{%
-        \resizebox{.8\paperheight}{!}{%
-            \input{\texpath/diab_summary.tex}
-        }
-%    }
+    \resizebox{.8\paperheight}{!}{%
+        \input{chapters/data/paper/tex/diab_summary.tex}
+    }
     \caption{%
         Spell-level statistics for each of the key attributes in the diabetic
         population (and non-diabetic population in parentheses)

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -283,7 +283,7 @@ most prominent levels of interaction.
 \end{definition}
 
 \begin{figure}
-    \resizebox{\textwidth}{!}{%
+    \resizebox{.95\textwidth}{!}{%
         \includegraphics[width=\linewidth]{corr_heatmap.pdf}
     }
     \caption{%
@@ -558,8 +558,21 @@ patients represent a population whose spells are more severe on average than the
 typical patient. Therefore, they will likely have a larger effect on the
 hospital system on the whole. A more detailed breakdown of the skeleton for each
 of these attributes as well as the other key attributes is given in
-Appendix~\ref{app:tables}. Table~\ref{tab:diab_summary} also shows a comparison
-between both populations being considered in this section.
+Table~\ref{tab:diab_summary}. This table also shows a comparison between both
+populations being considered in this section.
+
+\begin{sidewaystable}
+    \centering
+%    \rotatebox{90}{%
+        \resizebox{.8\paperheight}{!}{%
+            \input{\texpath/diab_summary.tex}
+        }
+%    }
+    \caption{%
+        Spell-level statistics for each of the key attributes in the diabetic
+        population (and non-diabetic population in parentheses)
+    }\label{tab:diab_summary}
+\end{sidewaystable}
 
 \begin{figure}
     \centering
@@ -604,7 +617,8 @@ non-diabetic population has been omitted as it is similar to that of the general
 population.
 
 \begin{figure}
-    \resizebox{\textwidth}{!}{%
+    \centering
+    \resizebox{.95\textwidth}{!}{%
         \includegraphics[width=\linewidth]{corr_heatmap.pdf}
     }
     \caption{%
@@ -614,7 +628,8 @@ population.
 \end{figure}
 
 \begin{figure}
-    \resizebox{\textwidth}{!}{%
+    \centering
+    \resizebox{.95\textwidth}{!}{%
         \includegraphics[width=\linewidth]{corr_diff_heatmap.pdf}
     }
     \caption{%

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -560,13 +560,12 @@ for each of these attributes as well as the other key attributes is given in
 Table~\ref{tab:diab_summary}. This table also shows a comparison between both
 populations being considered in this section.
 
-\iffalse
 \afterpage{%
     \thispagestyle{empty}
     \begin{landscape}
         \begin{table}
         \centering
-            \resizebox{.85\paperheight}{!}{%
+            \resizebox{.8\paperheight}{!}{%
                 \input{\texpath/diab_summary.tex}
             }
             \caption{%
@@ -576,7 +575,6 @@ populations being considered in this section.
         \end{table}
     \end{landscape}
 }
-\fi
 
 \begin{figure}
     \centering

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -565,7 +565,7 @@ populations being considered in this section.
     \begin{landscape}
         \begin{table}
         \centering
-            \resizebox{.8\paperheight}{!}{%
+            \resizebox{.85\paperheight}{!}{%
                 \input{\texpath/diab_summary.tex}
             }
             \caption{%

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -558,8 +558,8 @@ patients represent a population whose spells are more severe on average than the
 typical patient. Therefore, they will likely have a larger effect on the
 hospital system on the whole. A more detailed breakdown of the skeleton for each
 of these attributes as well as the other key attributes is given in
-Appendix~\ref{app:tables}. That table also shows a comparison between both
-populations being considered in this section.
+Appendix~\ref{app:tables}. Table~\ref{tab:diab_summary} also shows a comparison
+between both populations being considered in this section.
 
 \begin{figure}
     \centering

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -560,8 +560,6 @@ for each of these attributes as well as the other key attributes is given in
 Table~\ref{tab:diab_summary}. This table also shows a comparison between both
 populations being considered in this section.
 
-\afterpage{%
-    \thispagestyle{empty}
     \begin{landscape}
         \begin{table}
         \centering
@@ -574,7 +572,6 @@ populations being considered in this section.
             }\label{tab:diab_summary}
         \end{table}
     \end{landscape}
-}
 
 \begin{figure}
     \centering

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -560,6 +560,7 @@ for each of these attributes as well as the other key attributes is given in
 Table~\ref{tab:diab_summary}. This table also shows a comparison between both
 populations being considered in this section.
 
+\iffalse
 \afterpage{%
     \thispagestyle{empty}
     \begin{landscape}
@@ -575,6 +576,7 @@ populations being considered in this section.
         \end{table}
     \end{landscape}
 }
+\fi
 
 \begin{figure}
     \centering

--- a/chapters/data/main.tex
+++ b/chapters/data/main.tex
@@ -560,7 +560,10 @@ for each of these attributes as well as the other key attributes is given in
 Table~\ref{tab:diab_summary}. This table also shows a comparison between both
 populations being considered in this section.
 
+\afterpage{%
+    \clearpage%
     \begin{landscape}
+        \thispagestyle{empty}
         \begin{table}
         \centering
             \resizebox{.8\paperheight}{!}{%
@@ -572,6 +575,7 @@ populations being considered in this section.
             }\label{tab:diab_summary}
         \end{table}
     \end{landscape}
+}
 
 \begin{figure}
     \centering

--- a/main.tex
+++ b/main.tex
@@ -27,11 +27,16 @@
 
 \renewcommand{\chaptermark}[1]{%
     \markboth{\MakeUppercase{\thechapter.\ #1}}{}  % Number and title only
-} 
+}
+
+\renewcommand{\sectionmark}[1]{%
+    \markright{\MakeUppercase{\thesection.\ #1}}{}  % Number and title only
+}
 
 \fancypagestyle{normal}{  % Used for most pages
     \fancyhf{}
-    \fancyhead[LE,RO]{\slshape\leftmark}  % Show chapter title on outer leaf
+    \fancyhead[LE]{\slshape\leftmark}  % Show chapter title on outer leaf
+    \fancyhead[RO]{\slshape\rightmark}
     \fancyfoot[LE,RO]{\thepage}  % Show page number on outer leaf
     \renewcommand{\headrulewidth}{1pt}
 }
@@ -42,13 +47,19 @@
 }
 \patchcmd{\chapter}{\thispagestyle{plain}}{\thispagestyle{chapterstyle}}{}{}
 
+\fancypagestyle{appendixstyle}{  % For appendices
+    \fancyhf{}
+    \fancyhead[LE,RO]{\slshape\rightmark}
+    \fancyfoot[LE,RO]{\thepage}
+}
+
 % Images, lists and tables
 \usepackage{booktabs}
 \usepackage{graphicx}
 \usepackage{standalone}
 \usepackage{tikz}
 
-% Bibliography and links
+% Bibliography, appendices and links
 \usepackage{float}  % Force hyperref to patch float [for minted]
 \usepackage{hyperref}
 \usepackage[numbers]{natbib}

--- a/main.tex
+++ b/main.tex
@@ -56,6 +56,7 @@
 % Images, lists and tables
 \usepackage{booktabs}
 \usepackage{graphicx}
+\usepackage{rotating}
 \usepackage{standalone}
 \usepackage{tikz}
 


### PR DESCRIPTION
The large diabetic summary table has to be landscape but I can't use `\afterpage` with `latexmk` v4.41 (latest on Ubuntu). So, this uses the `sidewaystable` environment to get around that.