### PR TITLE
Add "Introduction to queuing" section to COPD chapter

### DIFF
--- a/.bibliography.bib
+++ b/.bibliography.bib
@@ -2076,6 +2076,18 @@ F. and Fone, D.},
     year = {2017}
 }
 
+@article{Kingman2009,
+    author = {J. F. C. Kingman},
+    doi = {10.1007/s11134-009-9147-4},
+    journal = {Queueing Systems},
+    number = {1-4},
+    pages = {3--12},
+    publisher = {Springer Science and Business Media {LLC}},
+    title = {The first Erlang century{\textemdash}and the next},
+    volume = {63},
+    year = {2009}
+}
+
 @article{Kiselev2019,
     author = {Vladimir Yu Kiselev and Tallulah S. Andrews and Martin Hemberg},
     doi = {10.1038/s41576-018-0088-9},
@@ -2282,6 +2294,18 @@ numerical optimization},
     title = {Fuzzy Clustering Algorithms — Review of the Applications},
     volume = {},
     year = {2016}
+}
+
+@article{Little1961,
+    author = {John D. C. Little},
+    doi = {10.1287/opre.9.3.383},
+    journal = {Operations Research},
+    number = {3},
+    pages = {383--387},
+    publisher = {Institute for Operations Research and the Management Sciences ({INFORMS})},
+    title = {A Proof for the Queuing Formula:L= $\uplambda$W},
+    volume = {9},
+    year = {1961}
 }
 
 @article{Liu2009,

--- a/.bibliography.bib
+++ b/.bibliography.bib
@@ -355,6 +355,18 @@ selection mechanisms},
     year = {2017 (accessed \today)}
 }
 
+@article{Bell1987,
+    author = {Peter C. Bell and Robert M. O{\textquotesingle}Keefe},
+    doi = {10.1177/003754978704900304},
+    journal = {{SIMULATION}},
+    number = {3},
+    pages = {109--116},
+    publisher = {{SAGE} Publications},
+    title = {Visual Interactive Simulation {\textemdash} History,  recent developments,  and major issues},
+    volume = {49},
+    year = {1987}
+}
+
 @article{Belle2015,
     author = {Belle, Ashwin and Thiagarajan, Raghuram and Soroushmehr, SM and Navidi, Fatemeh and Beard, Daniel A and Najarian, Kayvan},
     doi = {10.1155/2015/370194},
@@ -798,6 +810,18 @@ Comparison of Three Crossover Methods},
     year = {2019}
 }
 
+@article{Cochran2009,
+    author = {Jeffery K. Cochran and Kevin T. Roche},
+    doi = {10.1016/j.cor.2008.02.004},
+    journal = {Computers {\&} Operations Research},
+    number = {5},
+    pages = {1497--1512},
+    publisher = {Elsevier {BV}},
+    title = {A multi-class queuing network analysis methodology for improving hospital emergency department performance},
+    volume = {36},
+    year = {2009}
+}
+
 @inproceedings{CohenAddad2018,
     author = {Vincent Cohen-Addad and Varun Kanade and Frederik Mallmann-Trenn and Claire Mathieu},
     booktitle = {Proceedings of the 2018 Annual ACM-SIAM Symposium on Discrete Algorithms},
@@ -890,6 +914,18 @@ Using the Integrated City Sustainability Database},
     title = {Machine intelligence in healthcare{\textemdash}perspectives on trustworthiness,  explainability,  usability,  and transparency},
     volume = {3},
     year = {2020}
+}
+
+@article{Dagkakis2016,
+    author = {G Dagkakis and C Heavey},
+    doi = {10.1057/jos.2015.9},
+    journal = {Journal of Simulation},
+    number = {3},
+    pages = {193--206},
+    publisher = {Informa {UK} Limited},
+    title = {A review of open source discrete event simulation software for operations research},
+    volume = {10},
+    year = {2016}
 }
 
 @article{Dahmen2019,

--- a/.bibliography.bib
+++ b/.bibliography.bib
@@ -462,6 +462,19 @@ development of algorithm to identify high risk patients},
     year = {2012}
 }
 
+@article{Bittencourt2018,
+    address = {Bradford, England :},
+    author = {Bittencourt, Otavio and Verter, Vedat and Yalovsky, Morty},
+    issn = {1741-0401},
+    journal = {International journal of productivity and performance management.},
+    number = {2},
+    pages = {224--238},
+    publisher = {Emerald,},
+    title = {Hospital capacity management based on the queueing theory},
+    volume = {67},
+    year = {2018}
+}
+
 @misc{BMA2020,
     author = {{British Medical Association}},
     title = {Models for paying providers of {NHS} services},

--- a/.bibliography.bib
+++ b/.bibliography.bib
@@ -406,6 +406,14 @@ selection mechanisms},
     year = {1978}
 }
 
+@book{Bhat2015,
+    author = {U. Narayan Bhat},
+    doi = {10.1007/978-0-8176-8421-1},
+    publisher = {Birkh\"{a}user Boston},
+    title = {An Introduction to Queueing Theory},
+    year = {2015}
+}
+
 @article{Bhattacharjee2014,
     author = {Papiya Bhattacharjee and Pradip Kumar Ray},
     doi = {10.1016/j.cie.2014.04.016},
@@ -3383,6 +3391,14 @@ optimization based on evolution strategies},
     year = {2015}
 }
 
+@book{Shortle2018,
+    author = {John F Shortle and James M Thompson and Donald Gross and Carl M Harris},
+    doi = {10.1002/9781119453765},
+    publisher = {John Wiley {\&} Sons,  Inc.},
+    title = {Fundamentals of Queueing Theory},
+    year = {2018}
+}
+
 @article{Sibson1973,
     author = {Sibson, R.},
     doi = {10.1093/comjnl/16.1.30},
@@ -3545,6 +3561,14 @@ rehabilitation in {England} and {Wales}},
 requirements},
     volume = {68},
     year = {2013}
+}
+
+@book{Stewart2009,
+    author = {William J. Stewart},
+    doi = {10.2307/j.ctvcm4gtc},
+    publisher = {Princeton University Press},
+    title = {Probability,  Markov Chains,  Queues,  and Simulation},
+    year = {2009}
 }
 
 @inproceedings{Suganuma2017,

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -2076,6 +2076,18 @@ F. and Fone, D.},
     year = {2017}
 }
 
+@article{Kingman2009,
+    author = {J. F. C. Kingman},
+    doi = {10.1007/s11134-009-9147-4},
+    journal = {Queueing Systems},
+    number = {1-4},
+    pages = {3--12},
+    publisher = {Springer Science and Business Media {LLC}},
+    title = {The first Erlang century{\textemdash}and the next},
+    volume = {63},
+    year = {2009}
+}
+
 @article{Kiselev2019,
     author = {Vladimir Yu Kiselev and Tallulah S. Andrews and Martin Hemberg},
     doi = {10.1038/s41576-018-0088-9},
@@ -2282,6 +2294,18 @@ numerical optimization},
     title = {Fuzzy Clustering Algorithms — Review of the Applications},
     volume = {},
     year = {2016}
+}
+
+@article{Little1961,
+    author = {John D. C. Little},
+    doi = {10.1287/opre.9.3.383},
+    journal = {Operations Research},
+    number = {3},
+    pages = {383--387},
+    publisher = {Institute for Operations Research and the Management Sciences ({INFORMS})},
+    title = {A Proof for the Queuing Formula:L= $\uplambda$W},
+    volume = {9},
+    year = {1961}
 }
 
 @article{Liu2009,

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -355,6 +355,18 @@ selection mechanisms},
     year = {2017 (accessed \today)}
 }
 
+@article{Bell1987,
+    author = {Peter C. Bell and Robert M. O{\textquotesingle}Keefe},
+    doi = {10.1177/003754978704900304},
+    journal = {{SIMULATION}},
+    number = {3},
+    pages = {109--116},
+    publisher = {{SAGE} Publications},
+    title = {Visual Interactive Simulation {\textemdash} History,  recent developments,  and major issues},
+    volume = {49},
+    year = {1987}
+}
+
 @article{Belle2015,
     author = {Belle, Ashwin and Thiagarajan, Raghuram and Soroushmehr, SM and Navidi, Fatemeh and Beard, Daniel A and Najarian, Kayvan},
     doi = {10.1155/2015/370194},
@@ -798,6 +810,18 @@ Comparison of Three Crossover Methods},
     year = {2019}
 }
 
+@article{Cochran2009,
+    author = {Jeffery K. Cochran and Kevin T. Roche},
+    doi = {10.1016/j.cor.2008.02.004},
+    journal = {Computers {\&} Operations Research},
+    number = {5},
+    pages = {1497--1512},
+    publisher = {Elsevier {BV}},
+    title = {A multi-class queuing network analysis methodology for improving hospital emergency department performance},
+    volume = {36},
+    year = {2009}
+}
+
 @inproceedings{CohenAddad2018,
     author = {Vincent Cohen-Addad and Varun Kanade and Frederik Mallmann-Trenn and Claire Mathieu},
     booktitle = {Proceedings of the 2018 Annual ACM-SIAM Symposium on Discrete Algorithms},
@@ -890,6 +914,18 @@ Using the Integrated City Sustainability Database},
     title = {Machine intelligence in healthcare{\textemdash}perspectives on trustworthiness,  explainability,  usability,  and transparency},
     volume = {3},
     year = {2020}
+}
+
+@article{Dagkakis2016,
+    author = {G Dagkakis and C Heavey},
+    doi = {10.1057/jos.2015.9},
+    journal = {Journal of Simulation},
+    number = {3},
+    pages = {193--206},
+    publisher = {Informa {UK} Limited},
+    title = {A review of open source discrete event simulation software for operations research},
+    volume = {10},
+    year = {2016}
 }
 
 @article{Dahmen2019,

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -462,6 +462,19 @@ development of algorithm to identify high risk patients},
     year = {2012}
 }
 
+@article{Bittencourt2018,
+    address = {Bradford, England :},
+    author = {Bittencourt, Otavio and Verter, Vedat and Yalovsky, Morty},
+    issn = {1741-0401},
+    journal = {International journal of productivity and performance management.},
+    number = {2},
+    pages = {224--238},
+    publisher = {Emerald,},
+    title = {Hospital capacity management based on the queueing theory},
+    volume = {67},
+    year = {2018}
+}
+
 @misc{BMA2020,
     author = {{British Medical Association}},
     title = {Models for paying providers of {NHS} services},

--- a/bibliography.bib
+++ b/bibliography.bib
@@ -406,6 +406,14 @@ selection mechanisms},
     year = {1978}
 }
 
+@book{Bhat2015,
+    author = {U. Narayan Bhat},
+    doi = {10.1007/978-0-8176-8421-1},
+    publisher = {Birkh\"{a}user Boston},
+    title = {An Introduction to Queueing Theory},
+    year = {2015}
+}
+
 @article{Bhattacharjee2014,
     author = {Papiya Bhattacharjee and Pradip Kumar Ray},
     doi = {10.1016/j.cie.2014.04.016},
@@ -3383,6 +3391,14 @@ optimization based on evolution strategies},
     year = {2015}
 }
 
+@book{Shortle2018,
+    author = {John F Shortle and James M Thompson and Donald Gross and Carl M Harris},
+    doi = {10.1002/9781119453765},
+    publisher = {John Wiley {\&} Sons,  Inc.},
+    title = {Fundamentals of Queueing Theory},
+    year = {2018}
+}
+
 @article{Sibson1973,
     author = {Sibson, R.},
     doi = {10.1093/comjnl/16.1.30},
@@ -3545,6 +3561,14 @@ rehabilitation in {England} and {Wales}},
 requirements},
     volume = {68},
     year = {2013}
+}
+
+@book{Stewart2009,
+    author = {William J. Stewart},
+    doi = {10.2307/j.ctvcm4gtc},
+    publisher = {Princeton University Press},
+    title = {Probability,  Markov Chains,  Queues,  and Simulation},
+    year = {2009}
 }
 
 @inproceedings{Suganuma2017,

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -543,6 +543,7 @@ but some commonly studied examples are:
 
 \subsection{Some well-known queues}\label{subsec:known}
 
+One of the 
 
 \subsection{Simulation tools}\label{subsec:tools}
 
@@ -582,37 +583,37 @@ described in this section.
 It is often the case that in practical situations where suitable data is not
 (immediately) available, further inquiry in that line of research will stop.
 Queuing models in healthcare settings appear to be such a case; the line ends at
-incomplete queue data.~\cite{Asanjarani2017} is a bibliographic work that
-collates articles on the estimation of queuing system characteristics ---
-including their parameters. Despite its breadth of almost 300 publications from
-1955, only two articles have been identified as being applied to
+incomplete queue data. The bibliographic work~\cite{Asanjarani2017} collates
+articles on the estimation of queuing system characteristics --- including their
+parameters. Despite its breadth of almost 300 publications from 1955, only two
+articles have been identified as being applied to
 healthcare:~\cite{Mohammadi2012,Yom2014}. Both works are concerned with
 customers who can re-enter services during their time in the queuing system,
 which is mainly of value when considering the effect of unpredictable behaviour
-in intensive care units, for instance.~\cite{Mohammadi2012} seeks to approximate
-service and re-service densities through a Bayesian approach and by filtering
-out those customers seeking to be serviced again. Meanwhile,~\cite{Yom2014}
-considers an extension to the \(M/M/c\) queue with direct re-entries. The
-devised model is then used to determine resource requirements in two healthcare
-settings.
+in intensive care units, for instance. In~\cite{Mohammadi2012}, the authors seek
+to approximate service and re-service densities through a Bayesian approach and
+by filtering out those customers seeking to be serviced again. Meanwhile, the
+approach in~\cite{Yom2014} considers an extension to the \(M/M/c\) queue with
+direct re-entries. The devised model is then used to determine resource
+requirements in two healthcare settings.
 
 Aside from healthcare-specific works, the approximation of queue parameters has
 formed a part of relevant modern queuing research. However, the scope is
-primarily focused on theoretic approximations rather than by
-simulation.~\cite{Djabali2018,Goldenshluger2016} are two such recent works that
-consider an underlying process to estimate a general service time distribution
-in single server and infinite server queues respectively.
+primarily focused on theoretic approximations rather than by simulation. For
+instance, two recent works~\cite{Djabali2018,Goldenshluger2016} consider an
+underlying process to estimate a general service time distribution in single
+server and infinite server queues respectively.
 
 While these solutions are interesting, they do not necessarily tackle the issue
 in this scenario where information about the system is also missing. With that,
 there is a precedent for simplifying healthcare systems to a single node with
-parallel servers that emulate overall resource
-availability.~\cite{Steins2013}~and~\cite{Williams2015} provide examples of how
-this approach, when paired with discrete event simulation, can expose the
-resource needs of a system beyond deterministic queuing theory models. In
-particular,~\cite{Williams2015} shows how a single node, multiple server queue
-can be used to accurately predict bed capacity and length of stay distributions
-in a critical care unit using administrative data.
+parallel servers that emulate overall resource availability. Two
+studies~\cite{Steins2013,Williams2015} provide examples of how this approach,
+when paired with discrete event simulation, can expose the resource needs of a
+system beyond deterministic queuing theory models. In particular, the authors
+of~\cite{Williams2015} show how a single node, multiple server queue can be used
+to accurately predict bed capacity and length of stay distributions in a
+critical care unit using administrative data.
 
 \begin{figure}
     \centering%
@@ -849,7 +850,7 @@ value in the base case, meaning that a metric having a value of 1 is `normal'.
 As mentioned in Section~\ref{sec:intro}, the source code used throughout this
 work is available has been archived online under~\doi{10.5281/zenodo.3936479}.
 Also, the datasets generated from the simulations in this section, and the
-parameter sweep, have been archived online~\doi{doi:10.5281/zenodo.3924715}.
+parameter sweep, have been archived online~\doi{10.5281/zenodo.3924715}.
 % TODO Archive new data and update these DOIs.
 
 

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -452,8 +452,8 @@ As discussed earlier, the purpose of this chapter is to construct a queuing
 model for the data described here. Insights have already been gained into the
 needs of the segments that have been identified in this section. However, to
 glean further insights, some parameters of the queuing model must be recovered
-from the data. The following two sections briefly introduce queuing theory, and
-describe how these parameters are derived, respectively.
+from the data. The following two sections briefly introduce queues, and describe
+how these parameters are derived using the dataset at hand, respectively.
 
 
 \section{An introduction to queues}\label{sec:queuing}
@@ -481,8 +481,6 @@ examples
 include~\cite{Bittencourt2018,Mohammadi2012,Steins2013,Williams2015,Yom2014}.
 
 % TODO subsections on the following:
-%    - basic elements (arrival process, service process, capacities, discipline)
-%      leading to Kendall's notation
 %    - the M/M/c and M/G/c queues (embedding Markov process?)
 %    - tools used to simulate queues (ciw, simul8, omnet++, excel, simpy)
 
@@ -493,19 +491,21 @@ within that facility, a line in which customers wait to be served, and a stream
 of arriving customers. Figure~\ref{fig:queue} shows a diagram of a queue. The
 characteristics associated with the components of a queue are often summarised
 using Kendall's notation~\cite{Stewart2009}. The exact notation varies somewhat,
-but here it shall be denoted \(A/S/c/m/K/Q\). This notation acts as a shorthand
-to fully describe a queue, and is as follows.
+but here it shall be denoted \(A/S/c/m/K/Q\). This notation also defines the
+\emph{parameters} of the queue. The process in Section~\ref{sec:model} estimates
+some unknown parameters of a queue.
 
-\begin{figure}
+\begin{figure}[htbp]
     \resizebox{\textwidth}{!}{%
         \input{chapters/copd/tex/queue}
     }\caption{The anatomy of a queue}\label{fig:queue}
 \end{figure}
 
-Customers arrive to the queue according to an \emph{inter-arrival time
+Kendall's notation acts as a shorthand to fully describe a queue, and is as
+follows. Customers arrive to the queue according to an \emph{inter-arrival time
 distribution}, \(A\), and wait in line to be served according to a \emph{queuing
 discipline}, \(Q\). Typically, customers are served as they arrive. This
-discipline is denoted FIFO (first in first out). Other disciplines include LIFO
+discipline is called FIFO (first in first out). Other disciplines include LIFO
 (last in first out) and priority scheduling --- as used in emergency triage. At
 the service facility there are \(c\) parallel servers, who each serve customers
 according to the \emph{service time distribution}, \(S\). Sometimes it is
@@ -531,10 +531,6 @@ but some commonly studied examples are:
     \item General (denoted \(G\)). Arrivals are random, and inter-arrival or
         service times follow a general probability distribution.
 \end{itemize}
-
-\subsection{Multi-server queues}\label{subsec:multiserver}
-
-
 
 \subsection{Simulation tools}\label{subsec:tools}
 

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -96,6 +96,8 @@ The chapter is structured as follows:
 \begin{itemize}
     \item Section~\ref{sec:intro} provides an overview of the dataset and its
         clustering;
+    \item Section~\ref{sec:queuing} offers a concise introduction to queuing
+        theory;
     \item Section~\ref{sec:model} describes the queuing model used and the
         estimation of its parameters;
     \item Section~\ref{sec:scenarios} presents several what-if scenarios with
@@ -446,11 +448,43 @@ both interventions for their COPD (or either, in fact) have disproportionately
 fewer LTCs and concurrent ICDs when compared to the population. Aside from this,
 the profiles of each intervention are similar to one another.
 
-As discussed earlier, the purpose of this chapter is to construct a queuing model
-for the data described here. Insights have already been gained into the needs of
-the segments that have been identified in this section. However, to glean
-further insights, some parameters of the queuing model must be recovered from
-the data.
+As discussed earlier, the purpose of this chapter is to construct a queuing
+model for the data described here. Insights have already been gained into the
+needs of the segments that have been identified in this section. However, to
+glean further insights, some parameters of the queuing model must be recovered
+from the data. The following two sections briefly introduce queuing theory, and
+describe how these parameters are derived, respectively.
+
+
+\section{An introduction to queuing theory}\label{sec:queuing}
+
+Queues facilitate the orderly provision of services. Examples include lining up
+to board a bus, assembly lines in a factory, or patients arriving at a hospital.
+In all of these examples there are two types of agent: those providing the
+service (a bus driver), and those demanding it (the passengers). The generic
+terminology for these agents are \emph{servers} and \emph{customers},
+respectively. The characteristics of these queues may be varied, but they can be
+used to construct a mathematical model. Such a model would describe things like
+the process by which customers arrive to a queue, the rules that allow customers
+to be served, and the time taken to serve a customer. Queuing theory is the
+branch of mathematics concerned with the analysis of these models.
+
+The remainder of this section defines some of the fundamental elements used to
+discuss queues used in this chapter. This section does not cover many aspects of
+queuing theory that would typically be covered in an introductory course on the
+subject. Queuing theory is a mature discipline with many facets that extend
+beyond the needs of this chapter, and the scope of this thesis. Comprehensive
+and informative introductions to queuing models, queuing theory, and the
+simulating of queues can be found in~\cite{Bhat2015,Shortle2018,Stewart2009}.
+Furthermore, examples of queuing models being applied to healthcare systems are
+plentiful~\cite{}.
+% TODO add healthcare queuing citations
+
+% TODO subsections on the following:
+%    - basic elements (arrival process, service process, capacities, discipline)
+%      leading to Kendall's notation
+%    - the M/M/c and M/G/c queues (embedding Markov process?)
+
 
 \section{Constructing the queuing model}\label{sec:model}
 
@@ -458,6 +492,8 @@ The data available in this chapter is not as detailed as in comparative
 projects, limiting the options for how a queuing model may be constructed.
 Without access to such data --- but intending to gain insight from what is
 available --- it is imperative to bridge the gap left by the incomplete data.
+Figure~\ref{fig:process} provides a diagrammatic depiction of the process
+described in this section.
 
 It is often the case that in practical situations where suitable data is not
 (immediately) available, further inquiry in that line of research will stop.
@@ -503,9 +539,6 @@ in a critical care unit using administrative data.
         A diagrammatic depiction of the queuing parameter recovery process
     }\label{fig:process}
 \end{figure}
-
-Figure~\ref{fig:process} provides a diagrammatic depiction of the process
-described in this section.
 
 
 \subsection{Deriving the model parameters}\label{subsec:derive}

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -460,14 +460,22 @@ how these parameters are derived using the dataset at hand, respectively.
 
 Queues facilitate the orderly provision of services. Examples include lining up
 to board a bus, assembly lines in a factory, or patients arriving at a hospital.
-In all of these examples there are two types of agent: those providing the
+In all queues there are two types of agent: those providing the
 service (a bus driver), and those demanding it (the passengers). The generic
 terminology for these agents are \emph{servers} and \emph{customers},
-respectively. The characteristics of these queues may be varied, but they can be
-used to construct a mathematical model. Such a model would describe things like
-the process by which customers arrive to a queue, the rules that allow customers
-to be served, and the time taken to serve a customer. Queuing theory is the
-branch of mathematics concerned with the analysis of these models.
+respectively.
+
+As well as individual queues, networks of interconnecting queues can be
+described in a similar manner. In a \emph{queuing network}, each individual
+queue is called a \emph{node}. For instance, a hospital could be considered a
+network of queues, where patients arrive into triage, are processed, and are
+redirected throughout their spell.
+
+The observed characteristics of a queuing system can be used to construct a
+mathematical model. Such a model would describe things like the process by which
+customers arrive to a queue, the rules that allow customers to be served, and
+the time taken to serve a customer. Queuing theory is the branch of mathematics
+concerned with the analysis of these models.
 
 The remainder of this section defines some of the fundamental elements necessary
 to discuss the queues used in this chapter. This section omits many aspects of
@@ -477,12 +485,12 @@ beyond the needs of this chapter, and the scope of this thesis. Comprehensive
 and informative introductions to queuing models, queuing theory, and the
 simulating of queues can be found in~\cite{Bhat2015,Shortle2018,Stewart2009}.
 Further, applications of queuing models to healthcare systems are plentiful, but
-examples
-include~\cite{Bittencourt2018,Mohammadi2012,Steins2013,Williams2015,Yom2014}.
+examples include~\cite{%
+    Bittencourt2018,Cochran2009,Mohammadi2012,Steins2013,Williams2015,Yom2014%
+}.
 
 % TODO subsections on the following:
 %    - the M/M/c and M/G/c queues (embedding Markov process?)
-%    - tools used to simulate queues (ciw, simul8, omnet++, excel, simpy)
 
 \subsection{Elements of a queue}\label{subsec:elements}
 
@@ -496,7 +504,8 @@ but here it shall be denoted \(A/S/c/m/K/Q\). This notation also defines the
 some unknown parameters of a queue.
 
 \begin{figure}[htbp]
-    \resizebox{\textwidth}{!}{%
+    \centering%
+    \resizebox{\imgwidth}{!}{%
         \input{chapters/copd/tex/queue}
     }\caption{The anatomy of a queue}\label{fig:queue}
 \end{figure}
@@ -521,10 +530,10 @@ but some commonly studied examples are:
 \begin{itemize}
     \item Markovian (denoted \(M\)). Customers arrive according to a Poisson
         process. The inter-arrival or service times follow an exponential
-        distribution with rate \(\lambda > 0\), i.e. they have probability
+        distribution with rate \(\alpha > 0\), i.e. they have probability
         density function:
         \begin{equation}\label{eq:exponential}
-            f(t) = \lambda e^{-\lambda t}; \quad t \ge 0
+            f(t) = \alpha e^{-\alpha t}; \quad t \ge 0
         \end{equation}
     \item Deterministic (denoted \(D\)). Inter-arrival or service times are
         non-stochastic and are of fixed length.
@@ -532,7 +541,33 @@ but some commonly studied examples are:
         service times follow a general probability distribution.
 \end{itemize}
 
+\subsection{Some well-known queues}\label{subsec:known}
+
+
 \subsection{Simulation tools}\label{subsec:tools}
+
+As well as theoretical results, queues provide a valuable basis for computer
+simulation. Theoretical models are limited when studying complex queuing
+systems, where the parameterisation of a system requires complicated notation or
+derivations to produce useful results. When properly utilising computer
+simulation, the stochastic intricacies of a system may be more readily observed.
+Examples of such systems include the multi-class queuing networks studied
+in~\cite{Cochran2009}.
+
+There are numerous tools available for simulating queues, but many leave the
+associated research prone to issues like reproducibility --- as mentioned in
+Section~\ref{subsec:queuing}. A recent review on the subject and its tools
+is~\cite{Dagkakis2016}. One of the defining features of a simulation tool is
+whether it has a \emph{graphical user interface} (GUI) or not. GUIs provide
+accessibility to the non-technical members of a simulation project, but can also
+foster poor simulation practices~\cite{Bell1987}.
+
+The simulation framework of choice in this chapter is the discrete event
+simulation library, Ciw~\cite{Palmer2019}. Ciw is written in Python, and is a
+well-developed piece of open-source software, adhering to the same best
+practices as the other software packages developed during this project.
+In~\cite{Palmer2019}, the authors belabour how ensuring sustainable and
+reproducible simulation work are at the core of Ciw's development.
 
 
 \section{Constructing the queuing model}\label{sec:model}

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -489,9 +489,6 @@ examples include~\cite{%
     Bittencourt2018,Cochran2009,Mohammadi2012,Steins2013,Williams2015,Yom2014%
 }.
 
-% TODO subsections on the following:
-%    - the M/M/c and M/G/c queues (embedding Markov process?)
-
 \subsection{Elements of a queue}\label{subsec:elements}
 
 A queue is made up several components: the service facility, a number of servers
@@ -543,7 +540,84 @@ but some commonly studied examples are:
 
 \subsection{Some well-known queues}\label{subsec:known}
 
-One of the 
+\subsubsection{The \(M/M/1\) queue}
+
+One of the best-known queues is the \(M/M/1\) queue. In this queue, customers
+arrive according to a Poisson process at a rate, \(\lambda\). The customers are
+served by a single server exponentially, at a rate of \(\mu\). Owing to the
+memoryless property of the exponential distribution, this queue can be
+represented as a continuous-time Markov chain with state space \(\left\{0, 1, 2,
+\ldots\right\}\). This Markov chain is a birth-death process, as displayed in
+Figure~\ref{fig:birth_death_mm1}.
+
+\begin{figure}[htbp]
+    \centering
+    \resizebox{\imgwidth}{!}{%
+        \input{chapters/copd/tex/birth_death_mm1}
+    }\caption{
+        A state space diagram for an \(M/M/1\) queue%
+    }\label{fig:birth_death_mm1}
+\end{figure}
+
+An important property of the \(M/M/1\) queue is its \emph{traffic intensity},
+which is defined as \(\rho = \frac{\lambda}{\mu}\). This quantity also
+represents the proportion of time that the server spends serving customers, and
+so measures their \emph{utilisation}. The \(M/M/1\) queue is considered
+\emph{stable} (i.e. the underlying process will become stationary eventually) if
+\(\rho < 1\). In an unstable queue, customers arrive at a faster rate than they
+are served, and so the line grows indefinitely.
+
+Many other properties of the \(M/M/1\) queue can be explicitly derived from this
+representation, including steady-state solutions, the expected size of the
+system, and average response times. The calculation of these quantities also
+makes use of Little's Law~\cite{Little1961}, which relates average system size,
+\(L\), with average waiting time, \(W\), in stationary processes such that:
+\begin{equation}
+    L = \lambda W
+\end{equation}
+
+\subsubsection{The \(M/M/c\) queue}
+
+The \(M/M/c\) queue is an extension of the \(M/M/1\) queue where there are \(c
+\in \mathbb N\) independent servers working in parallel. Customers still arrive
+according to a Poisson process with rate, \(\lambda\), and customer service
+times follow an exponential distribution with a mean of \(\frac{1}{\mu}\). The
+traffic intensity of the \(M/M/c\) queue is also \(\rho = \frac{\lambda}{\mu}\),
+but server utilisation is measured as the mean traffic intensity across the
+servers, i.e.  \(\frac{\rho}{c}\). The stability condition for the \(M/M/c\)
+queue is \(\rho < c\). 
+
+As with the \(M/M/1\) queue, the \(M/M/c\) can be represented as a birth-death
+process on the state space \(\left\{0, 1, 2, \ldots\right\}\), as shown in
+Figure~\ref{fig:birth_death_mmc}. Since there are multiple servers, some servers
+may be idle when there are customers in the system. Once all servers are active,
+arriving customers join the line and wait for service. 
+
+\begin{figure}[htbp]
+    \centering
+    \resizebox{\imgwidth}{!}{%
+        \input{chapters/copd/tex/birth_death_mmc}
+    }\caption{
+        A state space diagram for an \(M/M/c\) queue%
+    }\label{fig:birth_death_mmc}
+\end{figure}
+
+\subsubsection{The \(M/G/c\) queue}
+
+As useful as memoryless service times are in deriving properties of queues, they
+are not always accurate to real systems. The \(M/G/c\) queue extends the
+\(M/M/c\) queue to allow for a general service time distribution. Again, there
+are \(c\) parallel servers and customers arrive randomly at a rate of
+\(\lambda\).
+
+The \(M/G/c\) queue cannot be represented as a Markov chain, but it is a
+stochastic process on the same state space as the other queues in this section.
+Given the generic nature of customer departure times, a lot of the structure of
+the underlying process is lost. As such, deriving exact values for many
+properties of the \(M/G/c\) queue continues to be an open
+problem~\cite{Kingman2009}. Despite the theoretical challenges posed by the
+\(M/G/c\), simulating these generic queues can still be of great benefit --- as
+is done in Section~\ref{sec:model}. 
 
 \subsection{Simulation tools}\label{subsec:tools}
 

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -566,8 +566,8 @@ The simulation framework of choice in this chapter is the discrete event
 simulation library, Ciw~\cite{Palmer2019}. Ciw is written in Python, and is a
 well-developed piece of open-source software, adhering to the same best
 practices as the other software packages developed during this project.
-In~\cite{Palmer2019}, the authors belabour how ensuring sustainable and
-reproducible simulation work are at the core of Ciw's development.
+In~\cite{Palmer2019}, the authors stress how ensuring sustainable and
+reproducible simulation work are at the core of their development process.
 
 
 \section{Constructing the queuing model}\label{sec:model}

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -478,9 +478,8 @@ the time taken to serve a customer. Queuing theory is the branch of mathematics
 concerned with the analysis of these models.
 
 The remainder of this section defines some of the fundamental elements necessary
-to discuss the queues used in this chapter. This section omits many aspects of
-queuing theory that would typically be covered in an introductory course on the
-subject. Queuing theory is a mature discipline with many facets that extend
+to discuss the queues used in this chapter. 
+Queuing theory is a mature discipline with many facets that extend
 beyond the needs of this chapter, and the scope of this thesis. Comprehensive
 and informative introductions to queuing models, queuing theory, and the
 simulating of queues can be found in~\cite{Bhat2015,Shortle2018,Stewart2009}.
@@ -500,12 +499,6 @@ but here it shall be denoted \(A/S/c/m/K/Q\). This notation also defines the
 \emph{parameters} of the queue. The process in Section~\ref{sec:model} estimates
 some unknown parameters of a queue.
 
-\begin{figure}[htbp]
-    \centering%
-    \resizebox{\imgwidth}{!}{%
-        \input{chapters/copd/tex/queue}
-    }\caption{The anatomy of a queue}\label{fig:queue}
-\end{figure}
 
 Kendall's notation acts as a shorthand to fully describe a queue, and is as
 follows. Customers arrive to the queue according to an \emph{inter-arrival time
@@ -520,6 +513,13 @@ omitted, an unlimited system capacity is presumed. The \emph{system capacity}
 can also be distinguished from an optional \emph{queue capacity}, \(m < K\),
 which limits the number of customers allowed to wait in line. Again, this is
 assumed to be \(\infty\), unless specified.
+
+\begin{figure}[htbp]
+    \centering%
+    \resizebox{\imgwidth}{!}{%
+        \input{chapters/copd/tex/queue}
+    }\caption{The anatomy of a queue}\label{fig:queue}
+\end{figure}
 
 The distributions used to model inter-arrival and service times are numerous,
 but some commonly studied examples are:
@@ -560,7 +560,7 @@ for all \(n \in \mathbb N\) and for any \((n+1)\)-tuple of states, \(s_0,
 \end{equation}
 
 That is, the probability of being in state \(s_n\) is dependent only on the
-previous state, \(s_{n-1}\). The Markov chain underlying the \(M/M/1\) is also
+previous state, \(s_{n-1}\). The Markov chain underlying an \(M/M/1\) queue is also
 known as a \emph{birth-death process}. Figure~\ref{fig:birth_death_mm1} shows a
 diagram of the birth-death process of an \(M/M/1\) queue.
 

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -484,6 +484,7 @@ plentiful~\cite{}.
 %    - basic elements (arrival process, service process, capacities, discipline)
 %      leading to Kendall's notation
 %    - the M/M/c and M/G/c queues (embedding Markov process?)
+%    - tools used to simulate queues (ciw, simul8, omnet++, excel, simpy)
 
 
 \section{Constructing the queuing model}\label{sec:model}

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -456,7 +456,7 @@ from the data. The following two sections briefly introduce queuing theory, and
 describe how these parameters are derived, respectively.
 
 
-\section{An introduction to queuing theory}\label{sec:queuing}
+\section{An introduction to queues}\label{sec:queuing}
 
 Queues facilitate the orderly provision of services. Examples include lining up
 to board a bus, assembly lines in a factory, or patients arriving at a hospital.
@@ -469,22 +469,74 @@ the process by which customers arrive to a queue, the rules that allow customers
 to be served, and the time taken to serve a customer. Queuing theory is the
 branch of mathematics concerned with the analysis of these models.
 
-The remainder of this section defines some of the fundamental elements used to
-discuss queues used in this chapter. This section does not cover many aspects of
+The remainder of this section defines some of the fundamental elements necessary
+to discuss the queues used in this chapter. This section omits many aspects of
 queuing theory that would typically be covered in an introductory course on the
 subject. Queuing theory is a mature discipline with many facets that extend
 beyond the needs of this chapter, and the scope of this thesis. Comprehensive
 and informative introductions to queuing models, queuing theory, and the
 simulating of queues can be found in~\cite{Bhat2015,Shortle2018,Stewart2009}.
-Furthermore, examples of queuing models being applied to healthcare systems are
-plentiful~\cite{}.
-% TODO add healthcare queuing citations
+Further, applications of queuing models to healthcare systems are plentiful, but
+examples
+include~\cite{Bittencourt2018,Mohammadi2012,Steins2013,Williams2015,Yom2014}.
 
 % TODO subsections on the following:
 %    - basic elements (arrival process, service process, capacities, discipline)
 %      leading to Kendall's notation
 %    - the M/M/c and M/G/c queues (embedding Markov process?)
 %    - tools used to simulate queues (ciw, simul8, omnet++, excel, simpy)
+
+\subsection{Elements of a queue}\label{subsec:elements}
+
+A queue is made up several components: the service facility, a number of servers
+within that facility, a line in which customers wait to be served, and a stream
+of arriving customers. Figure~\ref{fig:queue} shows a diagram of a queue. The
+characteristics associated with the components of a queue are often summarised
+using Kendall's notation~\cite{Stewart2009}. The exact notation varies somewhat,
+but here it shall be denoted \(A/S/c/m/K/Q\). This notation acts as a shorthand
+to fully describe a queue, and is as follows.
+
+\begin{figure}
+    \resizebox{\textwidth}{!}{%
+        \input{chapters/copd/tex/queue}
+    }\caption{The anatomy of a queue}\label{fig:queue}
+\end{figure}
+
+Customers arrive to the queue according to an \emph{inter-arrival time
+distribution}, \(A\), and wait in line to be served according to a \emph{queuing
+discipline}, \(Q\). Typically, customers are served as they arrive. This
+discipline is denoted FIFO (first in first out). Other disciplines include LIFO
+(last in first out) and priority scheduling --- as used in emergency triage. At
+the service facility there are \(c\) parallel servers, who each serve customers
+according to the \emph{service time distribution}, \(S\). Sometimes it is
+beneficial to attach a capacity to the system, denoted by \(K \ge c\). If
+omitted, an unlimited system capacity is presumed. The \emph{system capacity}
+can also be distinguished from an optional \emph{queue capacity}, \(m < K\),
+which limits the number of customers allowed to wait in line. Again, this is
+assumed to be \(\infty\), unless specified.
+
+The distributions used to model inter-arrival and service times are numerous,
+but some commonly studied examples are:
+
+\begin{itemize}
+    \item Markovian (denoted \(M\)). Customers arrive according to a Poisson
+        process. The inter-arrival or service times follow an exponential
+        distribution with rate \(\lambda > 0\), i.e. they have probability
+        density function:
+        \begin{equation}\label{eq:exponential}
+            f(t) = \lambda e^{-\lambda t}; \quad t \ge 0
+        \end{equation}
+    \item Deterministic (denoted \(D\)). Inter-arrival or service times are
+        non-stochastic and are of fixed length.
+    \item General (denoted \(G\)). Arrivals are random, and inter-arrival or
+        service times follow a general probability distribution.
+\end{itemize}
+
+\subsection{Multi-server queues}\label{subsec:multiserver}
+
+
+
+\subsection{Simulation tools}\label{subsec:tools}
 
 
 \section{Constructing the queuing model}\label{sec:model}

--- a/chapters/copd/main.tex
+++ b/chapters/copd/main.tex
@@ -546,9 +546,23 @@ One of the best-known queues is the \(M/M/1\) queue. In this queue, customers
 arrive according to a Poisson process at a rate, \(\lambda\). The customers are
 served by a single server exponentially, at a rate of \(\mu\). Owing to the
 memoryless property of the exponential distribution, this queue can be
-represented as a continuous-time Markov chain with state space \(\left\{0, 1, 2,
-\ldots\right\}\). This Markov chain is a birth-death process, as displayed in
-Figure~\ref{fig:birth_death_mm1}.
+represented as a continuous-time Markov chain over the state space
+\(\mathbb{N}_0 = \left\{0, 1, 2, \ldots\right\}\).
+
+A stochastic process, \(\left(X_t\right)\), which is defined over a countable
+state space, \(\mathcal S\), is considered a \emph{Markov chain} if and only if
+for all \(n \in \mathbb N\) and for any \((n+1)\)-tuple of states, \(s_0,
+\ldots, s_n \in \mathcal S^n\), the process satisfies:
+
+\begin{equation}
+    \mathbb P \left(X_n = s_n \ | \ X_{n-1} = s_{n-1}, \ldots, X_0 = s_0\right)
+    = \mathbb P \left(X_n = s_n \ | \ X_{n-1} = s_{n-1}\right)
+\end{equation}
+
+That is, the probability of being in state \(s_n\) is dependent only on the
+previous state, \(s_{n-1}\). The Markov chain underlying the \(M/M/1\) is also
+known as a \emph{birth-death process}. Figure~\ref{fig:birth_death_mm1} shows a
+diagram of the birth-death process of an \(M/M/1\) queue.
 
 \begin{figure}[htbp]
     \centering
@@ -588,7 +602,7 @@ servers, i.e.  \(\frac{\rho}{c}\). The stability condition for the \(M/M/c\)
 queue is \(\rho < c\). 
 
 As with the \(M/M/1\) queue, the \(M/M/c\) can be represented as a birth-death
-process on the state space \(\left\{0, 1, 2, \ldots\right\}\), as shown in
+process on the state space \(\mathbb N_0\), as shown in
 Figure~\ref{fig:birth_death_mmc}. Since there are multiple servers, some servers
 may be idle when there are customers in the system. Once all servers are active,
 arriving customers join the line and wait for service. 

--- a/chapters/copd/tex/birth_death_mm1.tex
+++ b/chapters/copd/tex/birth_death_mm1.tex
@@ -1,0 +1,36 @@
+\documentclass[border=5pt]{standalone}
+
+\usepackage{garamondx}
+\usepackage[garamondx,cmbraces]{newtxmath}
+
+\usepackage{tikz}
+
+\begin{document}
+
+\begin{tikzpicture}
+
+    \tikzstyle{state} = [ellipse, minimum width=4em, minimum height=3em]
+
+    \foreach \val/\lab in {0/0, 1/1, 2/2, 4/n-1, 5/n, 6/n+1} {%
+        \node[state, draw, thick] (\lab) at (\val * 2.5, 0) {\(\lab\)};
+    };
+
+    \node[state] (mid) at (3 * 2.5, 0) {\large\(\cdots\)};
+    \node[state] (end) at (7 * 2.5, 0) {\large\(\cdots\)};
+
+    \foreach \start/\end in {0/1, 1/2, 2/mid, mid/n-1, n-1/n, n/n+1, n+1/end} {%
+        \draw[-latex, thick]
+            (\start.north east)
+            to[out=30, in=150]
+            node[midway, above=1ex] {\(\lambda\)}
+            (\end.north west);
+        \draw[-latex, thick]
+            (\end.south west)
+            to[out=210, in=330]
+            node[midway, below=1ex] {\(\mu\)}
+            (\start.south east);
+    };
+
+\end{tikzpicture}
+
+\end{document}

--- a/chapters/copd/tex/birth_death_mmc.tex
+++ b/chapters/copd/tex/birth_death_mmc.tex
@@ -1,0 +1,44 @@
+\documentclass[border=5pt]{standalone}
+
+\usepackage{garamondx}
+\usepackage[garamondx,cmbraces]{newtxmath}
+
+\usepackage{tikz}
+
+\begin{document}
+
+\begin{tikzpicture}
+
+    \tikzstyle{state} = [ellipse, minimum width=4em, minimum height=3em]
+
+    \foreach \val/\lab in {0/0, 1/1, 2/2, 4/c-1, 5/c, 6/c+1} {%
+        \node[state, draw, thick] (\lab) at (\val * 2.5, 0) {\(\lab\)};
+    };
+
+    \node[state] (mid) at (3 * 2.5, 0) {\large\(\cdots\)};
+    \node[state] (end) at (7 * 2.5, 0) {\large\(\cdots\)};
+
+    \foreach \start/\end/\mul in {%
+        0/1/{},
+        1/2/2,
+        2/mid/3,
+        mid/c-1/(c-1),
+        c-1/c/c,
+        c/c+1/c,
+        c+1/end/c
+    } {%
+        \draw[-latex, thick]
+            (\start.north east)
+            to[out=30, in=150]
+            node[midway, above=1ex] {\(\lambda\)}
+            (\end.north west);
+        \draw[-latex, thick]
+            (\end.south west)
+            to[out=210, in=330]
+            node[midway, below=1ex] {\(\mul\mu\)}
+            (\start.south east);
+    };
+
+\end{tikzpicture}
+
+\end{document}

--- a/chapters/copd/tex/queue.tex
+++ b/chapters/copd/tex/queue.tex
@@ -1,0 +1,95 @@
+\documentclass[border=5pt]{standalone}
+
+\usepackage[T1]{fontenc}
+\usepackage{garamondx}
+\usepackage[garamondx,cmbraces]{newtxmath}
+\usepackage{tikz}
+    \usetikzlibrary{arrows,decorations}
+
+\tikzset{%
+    queue/.pic={%
+        code{%
+            \node (rect) at (38.5mm, 10mm) {};
+            \draw[thick] (0, 0) -- ++(40mm, 0) -- ++(0, 20mm) -- ++(-40mm, 0);
+            \foreach \val in {0, ..., #1}{%
+                \draw[thick] ([xshift=-\val*5mm] 40mm, 20mm) -- ++(0, -20mm);
+            };
+
+            \foreach \val/\lab/\size in {%
+                0/1/\scriptsize,
+                1/2/\scriptsize,
+                3/c-1/\tiny,
+                4/c/\scriptsize%
+            }{%
+                \node[draw, circle, thick, minimum size=9.5mm] (\lab)
+                    at (55mm, 29mm - \val * 9.5mm) {\size$\lab$};
+                \draw[-latex, thick] ([xshift=3mm]rect.east) -- (\lab.west);
+            };
+
+            \node at (55mm, 11mm) {$\vdots$};
+            \node at (5mm, 10mm) {$\cdots$};
+        };
+    },
+    myarrow/.style={%
+        line width=2mm,
+        draw=gray!50,
+        -triangle 60,
+        postaction={draw=gray!50, line width=4mm, shorten >=6mm, -},
+    },
+    double -latex/.style args={#1 colored by #2 and #3}{%
+        -latex,
+        line width=#1,
+        #2,
+        postaction={%
+            draw,
+            -latex,
+            #3,
+            line width=(#1)/3,
+            shorten <=(#1)/4,
+            shorten >=4.5*(#1)/3
+        },
+    },
+}
+
+\begin{document}
+
+\begin{tikzpicture}
+
+    \small
+    \path (0, 0) pic {queue=6};
+
+    \draw[-latex, thick] (-1, 1) to node[left, pos=0] {%
+        \color{gray}
+        \begin{tabular}{c}
+            Arriving\\
+            customers\\
+            \color{black}\(A\)
+        \end{tabular}
+    } (0, 1);
+
+    \draw[decorate, decoration={brace, amplitude=1ex}, thick]
+        (0, 2.5) -- ++(4, 0) node[midway, above=1ex] {%
+            \color{gray}
+            \begin{tabular}{c}
+                Customers\\
+                in line \color{black}\(Q\)
+            \end{tabular}
+        };
+
+    \foreach \val in {-1, 0, 2, 3}{%
+        \draw[-latex, thick] (6.1, \val * 9.5mm) -- ++(1, 0);
+    };
+
+    \draw[decorate, decoration={brace, amplitude=1ex}, thick]
+        (8, 3.25) -- ++(0, -4.5) node[midway, right=1ex] {%
+            \color{gray}
+            \begin{tabular}{c}
+                Servicing\\
+                customers\\
+                \color{black}\(S\)
+            \end{tabular}
+        };
+
+\end{tikzpicture}
+
+\end{document}

--- a/chapters/copd/tex/queue.tex
+++ b/chapters/copd/tex/queue.tex
@@ -72,7 +72,8 @@
             \color{gray}
             \begin{tabular}{c}
                 Customers\\
-                in line \color{black}\(Q\)
+                waiting in line\\
+                \color{black}\(Q\)
             \end{tabular}
         };
 

--- a/known.py
+++ b/known.py
@@ -111,6 +111,7 @@ words = {
     "ltcs",
     "lvaro",
     "mahalanobis",
+    "markovian",
     "matchingr",
     "matchings",
     "medoids",

--- a/known.py
+++ b/known.py
@@ -71,6 +71,7 @@ words = {
     "glamorgan",
     "glynatsi",
     "gregynog",
+    "guis",
     "hdbscan",
     "hoc",
     "hotspots",


### PR DESCRIPTION
@gillardjw pointed out that there wasn't enough support for queuing theory in the COPD chapter. In particular, this stood out against clustering, which has a lot of hand-holding throughout the thesis.

This section offers a brief overview of the elements required later in the chapter, and points at textbooks and articles for further reading.

Included in the section are the following subsections:

1. Basic elements leading to Kendall's notation (arrival and service processes, queue and system capacities, scheduling disciplines)
2. The M/M/c and M/G/c queues with a potential mention of the embedded Markov process (not necessary to go through deriving the Kolmogorov equations, just a mention)
3. Tools for simulating queues (Ciw, SimPy, OMNET++, Excel Spreadsheet modelling, Simul8)